### PR TITLE
🌟 feat : 포인트 사용 내역 컴포넌트 추가

### DIFF
--- a/e2e/pointHistory.spec.ts
+++ b/e2e/pointHistory.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('PointHistory 컴포넌트 E2E 테스트', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/points')
+  })
+
+  test('포인트 내역이 올바르게 표시되어야 함', async ({ page }) => {
+    const historyContainer = page.locator(
+      '[data-testid="point-history-container"]'
+    )
+    await expect(historyContainer).toBeVisible()
+
+    await expect(page.getByText('채팅 성공 보상')).toBeVisible()
+    await expect(page.getByText(/\d{4}\.\d{2}\.\d{2}/)).toBeVisible()
+    await expect(page.getByText(/[+-]\d+코인/)).toBeVisible()
+    await expect(page.getByText(/\d+코인$/)).toBeVisible()
+  })
+
+  test('적립과 사용 내역의 색상이 올바르게 표시되어야 함', async ({ page }) => {
+    const earnPoint = page.locator('.point-earn').first()
+    await expect(earnPoint).toHaveCSS('color', 'rgb(27, 91, 254)')
+
+    const usePoint = page.locator('.point-use').first()
+    await expect(usePoint).toHaveCSS('color', 'rgb(251, 79, 80)')
+  })
+
+  test('스크롤 시 포인트 내역이 올바르게 표시되어야 함', async ({ page }) => {
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+
+    const historyItems = await page
+      .locator('[data-testid="point-history-container"]')
+      .all()
+    expect(historyItems.length).toBeGreaterThan(1)
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import HomeCategoryButton from './components/home/homeCategoryButton.tsx'
 import ModalComponent from './components/modal/modalComponent'
 import InfoBox from './components/mypage/InfoBox'
 import MatchingGraph from './components/mypage/MatchingGraph'
+import PointHistory from './components/point/pointHistory'
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react'
 import { useState } from 'react'
@@ -503,6 +504,27 @@ function App() {
               isOpen={isModalOpen}
             />
           )}
+        </div>
+
+        <div
+          className="pointHistory"
+          style={{ width: '375px', margin: '10px 0 100px 0' }}
+        >
+          <PointHistory
+            historyName="포인트 충전"
+            historyDate="2025-01-17"
+            historyPoint={1000}
+            historyBalance={1000}
+            historyType="earn"
+          />
+
+          <PointHistory
+            historyName="포인트 사용"
+            historyDate="2025-01-16"
+            historyPoint={1000}
+            historyBalance={0}
+            historyType="use"
+          />
         </div>
 
         <div className="navigation" style={{ width: '50%' }}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -516,6 +516,8 @@ function App() {
             historyPoint={1000}
             historyBalance={1000}
             historyType="earn"
+            borderTop={false}
+            borderBottom={false}
           />
 
           <PointHistory

--- a/src/components/icon/__tests__/__snapshots__/iconComponents.snap.test.tsx.snap
+++ b/src/components/icon/__tests__/__snapshots__/iconComponents.snap.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Icon Snapshots > AlarmIcon matches snapshot 1`] = `
     class="icon-container css-1dts2m6"
   >
     <svg
-      class="alarm-icon css-jj5gyw"
+      class="alarm-icon css-122o3m0"
       fill="none"
       height="24"
       viewBox="0 0 24 24"
@@ -31,7 +31,7 @@ exports[`Icon Snapshots > SearchIcon with custom props matches snapshot 1`] = `
     class="icon-container css-1dts2m6"
   >
     <svg
-      class="search-icon css-jj5gyw"
+      class="search-icon css-122o3m0"
       fill="none"
       height="32"
       viewBox="0 0 24 24"

--- a/src/components/point/__tests__/pointHistory.test.tsx
+++ b/src/components/point/__tests__/pointHistory.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import PointHistory from '../pointHistory'
+
+describe('PointHistory 컴포넌트', () => {
+  const defaultProps = {
+    historyName: '매칭 성공 보상',
+    historyDate: '2024.03.24 18:52',
+    historyPoint: 50,
+    historyBalance: 1000,
+    historyType: 'earn' as const,
+    borderTop: true,
+    borderBottom: true,
+  }
+
+  describe('기본 렌더링', () => {
+    it('모든 정보가 올바르게 표시되어야 함', () => {
+      render(<PointHistory {...defaultProps} />)
+
+      expect(screen.getByText('매칭 성공 보상')).toBeInTheDocument()
+      expect(screen.getByText('2024.03.24 18:52')).toBeInTheDocument()
+      expect(screen.getByText('+50코인')).toBeInTheDocument()
+      expect(screen.getByText('1000코인')).toBeInTheDocument()
+    })
+
+    it('적립 타입일 때 파란색으로 표시되어야 함', () => {
+      render(<PointHistory {...defaultProps} />)
+
+      const pointElement = screen.getByText('+50코인')
+      expect(pointElement).toHaveStyle({ color: '#1B5BFE' })
+    })
+
+    it('사용 타입일 때 빨간색으로 표시되어야 함', () => {
+      render(<PointHistory {...defaultProps} historyType="use" />)
+
+      const pointElement = screen.getByText('-50코인')
+      expect(pointElement).toHaveStyle({ color: '#FB4F50' })
+    })
+  })
+
+  describe('테두리 스타일', () => {
+    it('상단 테두리가 있어야 함 (borderTop=true)', () => {
+      render(<PointHistory {...defaultProps} borderTop={true} />)
+
+      const container = screen.getByTestId('point-history-container')
+      expect(container).toHaveStyle({ borderTop: '1px solid #D9D9D9' })
+    })
+
+    it('하단 테두리가 있어야 함 (borderBottom=true)', () => {
+      render(<PointHistory {...defaultProps} borderBottom={true} />)
+
+      const container = screen.getByTestId('point-history-container')
+      expect(container).toHaveStyle({ borderBottom: '1px solid #D9D9D9' })
+    })
+
+    it('테두리가 없어야 함 (borderTop=false, borderBottom=false)', () => {
+      render(
+        <PointHistory
+          {...defaultProps}
+          borderTop={false}
+          borderBottom={false}
+        />
+      )
+
+      const container = screen.getByTestId('point-history-container')
+      expect(container).toHaveStyle({ borderTop: 'none', borderBottom: 'none' })
+    })
+  })
+
+  describe('레이아웃', () => {
+    it('좌우 정렬이 올바르게 되어야 함', () => {
+      render(<PointHistory {...defaultProps} />)
+
+      const container = screen.getByTestId('point-history-container')
+      expect(container).toHaveStyle({
+        display: 'flex',
+        justifyContent: 'space-between',
+      })
+    })
+
+    it('텍스트 정렬이 올바르게 되어야 함', () => {
+      render(<PointHistory {...defaultProps} />)
+
+      const leftSection = screen.getByTestId('point-history-left')
+      const rightSection = screen.getByTestId('point-history-right')
+
+      expect(leftSection).toHaveStyle({ alignItems: 'flex-start' })
+      expect(rightSection).toHaveStyle({ alignItems: 'flex-end' })
+    })
+  })
+})

--- a/src/components/point/pointHistory.tsx
+++ b/src/components/point/pointHistory.tsx
@@ -6,6 +6,60 @@ interface PointHistoryProps {
   historyDate: string
   historyPoint: number
   historyBalance: number
+  borderTop?: boolean
+  borderBottom?: boolean
+  historyType?: 'earn' | 'use'
+}
+
+const pointHistoryStyles = {
+  container: (borderTop: boolean, borderBottom: boolean) => css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    padding: 24px 0;
+    border-top: ${borderTop ? '1px solid #D9D9D9' : 'none'};
+    border-bottom: ${borderBottom ? '1px solid #D9D9D9' : 'none'};
+  `,
+  left: css`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 2px;
+  `,
+  right: css`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 2px;
+  `,
+
+  historyName: css`
+    font-size: 16px;
+    line-height: 1.5;
+    color: #000000;
+    margin: 0;
+  `,
+  historyDate: css`
+    font-size: 14px;
+    line-height: 1.4;
+    color: #727272;
+    margin: 0;
+  `,
+  historyPoint: (historyType: 'earn' | 'use') => css`
+    font-size: 16px;
+    font-weight: 700;
+    color: ${historyType === 'earn' ? '#1B5BFE' : '#FB4F50'};
+    margin: 0;
+  `,
+  historyBalance: css`
+    font-size: 14px;
+    line-height: 1.4;
+    color: #727272;
+    margin: 0;
+  `,
 }
 
 const PointHistory = ({
@@ -13,16 +67,25 @@ const PointHistory = ({
   historyDate,
   historyPoint,
   historyBalance,
+  historyType = 'earn',
+  borderTop = true,
+  borderBottom = true,
 }: PointHistoryProps) => {
   return (
-    <div className="container">
-      <div className="left">
-        <p>{historyName}</p>
-        <p>{historyDate}</p>
+    <div
+      className="container"
+      css={pointHistoryStyles.container(borderTop, borderBottom)}
+    >
+      <div className="left" css={pointHistoryStyles.left}>
+        <p css={pointHistoryStyles.historyName}>{historyName}</p>
+        <p css={pointHistoryStyles.historyDate}>{historyDate}</p>
       </div>
-      <div className="right">
-        <p>{historyPoint}</p>
-        <p>{historyBalance}</p>
+      <div className="right" css={pointHistoryStyles.right}>
+        <p css={pointHistoryStyles.historyPoint(historyType)}>
+          {historyType === 'earn' ? '+' : '-'}
+          {historyPoint}코인
+        </p>
+        <p css={pointHistoryStyles.historyBalance}>{historyBalance}코인</p>
       </div>
     </div>
   )

--- a/src/components/point/pointHistory.tsx
+++ b/src/components/point/pointHistory.tsx
@@ -1,0 +1,31 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react'
+
+interface PointHistoryProps {
+  historyName: string
+  historyDate: string
+  historyPoint: number
+  historyBalance: number
+}
+
+const PointHistory = ({
+  historyName,
+  historyDate,
+  historyPoint,
+  historyBalance,
+}: PointHistoryProps) => {
+  return (
+    <div className="container">
+      <div className="left">
+        <p>{historyName}</p>
+        <p>{historyDate}</p>
+      </div>
+      <div className="right">
+        <p>{historyPoint}</p>
+        <p>{historyBalance}</p>
+      </div>
+    </div>
+  )
+}
+
+export default PointHistory


### PR DESCRIPTION
## 📌 PR 내용
포인트 사용 내역 컴포넌트 추가

### 🛠 작업 내용
1. 포인트 사용 내역 컴포넌트 추가

2. border state 추가

3. 충전 및 사용 상태 추가

4. 상태에 따른 스타일 추가

### 📸 스크린샷
<img width="420" alt="image" src="https://github.com/user-attachments/assets/225eb0e7-854e-40d8-94a6-71a464a0d7f2" />




