### PR TITLE
🌟feat: 받은 평가 및 리뷰 TagReview 컴포넌트 추가

### DIFF
--- a/e2e/TagReview.spec.ts
+++ b/e2e/TagReview.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('TagReview 컴포넌트', () => {
+  test.beforeEach(async ({ page }) => {
+    // 애플리케이션의 메인 페이지로 이동
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    // 페이지 상단으로 스크롤
+    await page.evaluate(() => {
+      window.scrollTo(0, 0)
+    })
+  })
+
+  test('컴포넌트의 제목이 올바르게 표시된다', async ({ page }) => {
+    // 제목 확인
+    const title = page.getByText('받은 평가 및 리뷰', { exact: true }).first()
+    await expect(title).toBeVisible()
+  })
+
+  test('초기 상태에서 태그들이 표시된다', async ({ page }) => {
+    // '응답이 빨라요' 태그가 표시되는지 확인
+    const fastResponseTag = page
+      .locator('div')
+      .filter({ hasText: /12/ })
+      .filter({ hasText: /응답이 빨라요/ })
+      .first()
+    await expect(fastResponseTag).toBeVisible()
+
+    // 신뢰 태그가 표시되는지 확인
+    const trustTag = page
+      .locator('div')
+      .filter({ hasText: /9/ })
+      .filter({ hasText: /신뢰/ })
+      .first()
+    await expect(trustTag).toBeVisible()
+
+    // 공감 태그가 표시되는지 확인
+    const empathyTag = page
+      .locator('div')
+      .filter({ hasText: /8/ })
+      .filter({ hasText: /공감/ })
+      .first()
+    await expect(empathyTag).toBeVisible()
+  })
+
+  test('펼치기/접기 버튼이 있다', async ({ page }) => {
+    // 제목 요소 찾기
+    const title = page.getByText('받은 평가 및 리뷰', { exact: true }).first()
+
+    // 컨테이너 찾기 (제목이 있는 가장 가까운 부모)
+    const container = page.locator('div').filter({ has: title }).first()
+
+    // 컨테이너 내부에 버튼이 있는지 확인
+    const button = container.locator('button').first()
+    await expect(button).toBeVisible()
+  })
+
+  test('태그는 이모지와 텍스트와 숫자를 포함한다', async ({ page }) => {
+    // 첫 번째 태그 확인 (응답이 빨라요)
+    const firstTag = page
+      .locator('div')
+      .filter({ hasText: /응답이 빨라요/ })
+      .filter({ hasText: /12/ })
+      .first()
+
+    // 요소가 보이는지 확인
+    await expect(firstTag).toBeVisible()
+
+    // 내부 텍스트에 숫자가 포함되어 있는지 확인
+    const hasNumber = await firstTag.evaluate((el) => {
+      return /\d+/.test(el.textContent || '')
+    })
+    expect(hasNumber).toBeTruthy()
+
+    // 이모지 또는 특수문자가 포함되어 있는지 확인
+    const hasEmoji = await firstTag.evaluate((el) => {
+      // 간단한 이모지 탐지 (완벽하진 않지만 테스트 목적으로는 충분)
+      return /[\u{1F300}-\u{1F6FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F900}-\u{1F9FF}\u{1F600}-\u{1F64F}⚡]/u.test(
+        el.textContent || ''
+      )
+    })
+    expect(hasEmoji).toBeTruthy()
+  })
+
+  test('모바일 화면에서도 표시된다', async ({ page }) => {
+    // 모바일 뷰포트 설정
+    await page.setViewportSize({ width: 375, height: 667 })
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+
+    // 제목이 표시되는지 확인
+    const title = page.getByText('받은 평가 및 리뷰', { exact: true }).first()
+    await expect(title).toBeVisible()
+
+    // 태그가 하나 이상 표시되는지 확인
+    const firstTag = page
+      .locator('div')
+      .filter({ hasText: /응답이 빨라요/ })
+      .filter({ hasText: /12/ })
+      .first()
+    await expect(firstTag).toBeVisible()
+  })
+})

--- a/src/components/review/TagReview.tsx
+++ b/src/components/review/TagReview.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react'
+import {
+  TagReviewContainer,
+  TagReviewTitle,
+  TagListContainer,
+  TagItem,
+  TagText,
+  TagCount,
+  ExpandButton,
+  ArrowIcon,
+  TagLeftSection,
+} from '../../styles/TagReviewStyles'
+
+interface TagItem {
+  icon: string
+  text: string
+  count: number
+}
+
+interface TagReviewProps {
+  tags: TagItem[]
+  initialVisibleCount?: number
+}
+
+import { BackIcon } from '../icon/iconComponents'
+
+// 화살표 컴포넌트 분리
+const ArrowIconComponent: React.FC<{ isExpanded: boolean }> = ({
+  isExpanded,
+}) => {
+  return (
+    <ArrowIcon isExpanded={isExpanded}>
+      <BackIcon color="#666666" />
+    </ArrowIcon>
+  )
+}
+
+const TagReview: React.FC<TagReviewProps> = ({
+  tags,
+  initialVisibleCount = 3,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  const toggleExpand = () => {
+    setIsExpanded(!isExpanded)
+  }
+
+  const visibleTags = isExpanded ? tags : tags.slice(0, initialVisibleCount)
+
+  return (
+    <TagReviewContainer>
+      <TagReviewTitle>받은 평가 및 리뷰</TagReviewTitle>
+
+      <TagListContainer>
+        {visibleTags.map((tag, index) => (
+          <TagItem key={index}>
+            <TagLeftSection>
+              <TagText>{tag.icon}</TagText>
+              <TagText>{tag.text}</TagText>
+            </TagLeftSection>
+            <TagCount>{tag.count}</TagCount>
+          </TagItem>
+        ))}
+      </TagListContainer>
+
+      {tags.length > initialVisibleCount && (
+        <ExpandButton onClick={toggleExpand}>
+          <ArrowIconComponent isExpanded={isExpanded} />
+        </ExpandButton>
+      )}
+    </TagReviewContainer>
+  )
+}
+
+export default TagReview

--- a/src/pages/Devtools/index.tsx
+++ b/src/pages/Devtools/index.tsx
@@ -28,6 +28,7 @@ import CustomFormBubbleReceive from '../../components/chat/CustomFormBubbleRecei
 import ChatBar from '../../components/chat/ChatBar'
 import AskInput from '../../components/customForm/AskInput'
 import AnswerInput from '../../components/customForm/AnswerInput'
+import TagReview from '../../components/review/TagReview.tsx'
 import EmoticonComponent, {
   EmoticonType,
 } from '../../components/emoticon/Emoticon.tsx'
@@ -58,6 +59,16 @@ const bubbleContainerStyles = css`
   border-radius: 10px;
   margin: 20px 0;
 `
+
+// TagReview 테스트 데이터
+const reviewTags = [
+  { icon: '⚡', text: '응답이 빨라요', count: 12 },
+  { icon: '🤝', text: '신뢰할 수 있는 대화였어요', count: 9 },
+  { icon: '❤️', text: '공감을 잘해줘요', count: 8 },
+  { icon: '☕', text: '편안한 분위기에서 이야기할 수 있었어요', count: 6 },
+  { icon: '🎯', text: '솔직하고 현실적인 조언을 해줘요', count: 3 },
+  { icon: '💡', text: '새로운 관점을 제시해줘요', count: 1 },
+]
 
 const handleInputChange = (value: string) => {
   console.log('input 박스 값 변경되는가?? : ', value)
@@ -145,6 +156,12 @@ function App() {
             padding: '70px 20px 50px',
           }}
         >
+          {/* TagReview 컴포넌트 테스트 */}
+          <div
+            style={{ width: '100%', maxWidth: '480px', marginBottom: '30px' }}
+          >
+            <TagReview tags={reviewTags} />
+          </div>
           {/* 이모티콘 테스트 섹션 */}
           <div
             style={{
@@ -243,8 +260,6 @@ function App() {
               감사합니다!
             </Bubble>
           </div>
-
-          {/* 여기서부터는 기존 코드... */}
         </div>
 
         <div

--- a/src/styles/TagReviewStyles.tsx
+++ b/src/styles/TagReviewStyles.tsx
@@ -1,0 +1,85 @@
+import styled from '@emotion/styled'
+
+export const TagReviewContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: 16px;
+`
+
+export const TagReviewTitle = styled.h2`
+  font-family: 'Pretendard', sans-serif;
+  font-weight: bold;
+  font-size: 18px;
+  margin-bottom: 12px;
+`
+
+export const TagListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+`
+
+export const TagItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: #f5f5f5;
+  border-radius: 8px;
+  padding: 12px 20px;
+`
+
+export const TagLeftSection = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`
+
+export const TagText = styled.span`
+  font-family: 'Pretendard', sans-serif;
+  font-weight: bold;
+  padding: 0;
+  font-size: 14px;
+  color: #393939;
+`
+
+export const TagCount = styled.span`
+  font-family: 'Pretendard', sans-serif;
+  font-weight: bold;
+  font-size: 14px;
+  color: #393939;
+`
+
+export const ExpandButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 12px;
+  margin-top: 8px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  gap: 5px;
+  color: #393939;
+  font-family: 'Pretendard', sans-serif;
+  font-size: 14px;
+
+  &:active {
+    opacity: 0.7;
+  }
+`
+
+interface ArrowIconProps {
+  isExpanded: boolean
+}
+
+export const ArrowIcon = styled.div<ArrowIconProps>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: ${(props) =>
+    props.isExpanded ? 'rotate(90deg)' : 'rotate(-90deg)'};
+  transition: transform 0.3s ease;
+`

--- a/src/styles/TopBarStyles.tsx
+++ b/src/styles/TopBarStyles.tsx
@@ -9,7 +9,7 @@ export const TopBarContainer = styled.div`
   align-items: center;
   background-color: #ffffff;
   border-bottom: 1px solid #eeeeee;
-  position: sticky; /* fixed 대신 sticky 사용 */
+  position: sticky;
   top: 0;
   z-index: 5000;
 `


### PR DESCRIPTION
## 테스트 항목
- [x] TagReview 컴포넌트 정상 렌더링 확인
- [x] 태그 항목 및 개수 정확하게 표시되는지 확인
 - [x] 펼치기/접기 버튼 동작 및 아이콘 회전 확인
 - [x] 이모지와 텍스트가 왼쪽 정렬되고 개수가 오른쪽 정렬되는지 확인
 - [x] 모바일 환경에서 레이아웃 정상 표시 확인

## 🛰️ Issue Number
Close MM-139

## 🪐 작업 내용
- 사용자가 받은 평가 태그를 이모지와 함께 표시하는 TagReview 컴포넌트 구현
- 초기에는 3개의 태그만 표시하고 펼치기/접기 버튼으로 모든 태그 확인 가능
- BackIcon 활용한 펼치기/접기 버튼 구현 및 회전 (**선배님이 좋아하실만한 ㅋㅋ**)애니메이션 효과 추가

## 📸 스크린샷
<img width="384" alt="스크린샷 2025-04-04 오후 3 00 30" src="https://github.com/user-attachments/assets/2bf3ec7d-f40b-468a-9456-072d5ce2ca0a" />
<img width="389" alt="스크린샷 2025-04-04 오후 3 00 37" src="https://github.com/user-attachments/assets/935d7c1e-d0a1-4a79-a841-3161d635b4db" />
<img width="497" alt="스크린샷 2025-04-04 오후 4 02 14" src="https://github.com/user-attachments/assets/eb083a25-abe9-47ec-955c-ed5bdf8b5186" />
<img width="503" alt="스크린샷 2025-04-04 오후 4 02 22" src="https://github.com/user-attachments/assets/929a92a6-f22e-417c-9284-5f9d356147e9" />

