### PR TITLE
🌟 Feat: 프로필 이미지 클릭으로 사용자 프로필 페이지 이동 기능 추가

### DIFF
--- a/src/components/chat/Bubble.tsx
+++ b/src/components/chat/Bubble.tsx
@@ -20,6 +20,7 @@ interface BubbleProps {
   isLastMessage?: boolean
   isRead?: boolean
   isContinuous?: boolean
+  onProfileClick?: () => void // 프로필 클릭 핸들러 추가
 }
 
 const Bubble: React.FC<BubbleProps> = ({
@@ -31,7 +32,16 @@ const Bubble: React.FC<BubbleProps> = ({
   isLastMessage = false,
   isRead = false,
   isContinuous = false,
+  onProfileClick, // 프로필 클릭 핸들러 받기
 }) => {
+  // 프로필 이미지 클릭 핸들러
+  const handleProfileImageClick = (e: React.MouseEvent) => {
+    e.stopPropagation() // 부모 요소의 클릭 이벤트 방지
+    if (onProfileClick) {
+      onProfileClick()
+    }
+  }
+
   const checkForEmoticon = (child: React.ReactNode): boolean => {
     // React 요소인지 확인
     if (!React.isValidElement(child)) return false
@@ -73,6 +83,11 @@ const Bubble: React.FC<BubbleProps> = ({
           <ProfileImage
             src={profileImage}
             alt="프로필"
+            onClick={handleProfileImageClick} // 클릭 이벤트 추가
+            style={{
+              cursor: onProfileClick ? 'pointer' : 'default', // 클릭 가능할 때만 포인터 커서
+            }}
+            title={onProfileClick ? '프로필 보기' : undefined} // 툴팁 추가
             onError={(e) => {
               console.error('프로필 이미지 로드 실패:', profileImage)
               // 기본 이미지로 대체

--- a/src/components/matching/applicationInfo.tsx
+++ b/src/components/matching/applicationInfo.tsx
@@ -13,6 +13,7 @@ interface ApplicationInfoProps {
   onClick: () => void
   message: string
   borderSet: boolean
+  onProfileClick?: () => void // 프로필 클릭 핸들러 추가
 }
 
 const applicationInfoStyle = {
@@ -38,7 +39,6 @@ const applicationInfoStyle = {
     flex-direction: row;
     align-items: center;
     gap: 12px;
-    cursor: pointer;
   `,
 
   rightSide: css`
@@ -57,6 +57,12 @@ const applicationInfoStyle = {
     justify-content: center;
     align-items: center;
     overflow: hidden;
+    cursor: pointer; /* 클릭 가능 표시 */
+    transition: transform 0.2s ease; /* 호버 효과 */
+
+    &:hover {
+      transform: scale(1.05);
+    }
   `,
 
   profileImageStyle: css`
@@ -134,7 +140,16 @@ const applicationInfo = ({
   onClick,
   message,
   borderSet,
+  onProfileClick, // 프로필 클릭 핸들러 받기
 }: ApplicationInfoProps) => {
+  // 프로필 이미지 클릭 핸들러
+  const handleProfileImageClick = (e: React.MouseEvent) => {
+    e.stopPropagation() // 부모 요소의 클릭 이벤트 방지
+    if (onProfileClick) {
+      onProfileClick()
+    }
+  }
+
   return (
     <div className="container" css={applicationInfoStyle.container(borderSet)}>
       <div className="user-profile" css={applicationInfoStyle.userProfile}>
@@ -142,10 +157,13 @@ const applicationInfo = ({
           <div
             className="profile-image"
             css={applicationInfoStyle.profileImageWrapper}
+            onClick={handleProfileImageClick} // 프로필 이미지 클릭 이벤트 추가
+            title={`${name}의 프로필 보기`} // 툴팁 추가
           >
             <img
               src={profileImage}
               css={applicationInfoStyle.profileImageStyle}
+              alt={`${name}의 프로필 이미지`}
             />
           </div>
 

--- a/src/components/modal/modalComponent.tsx
+++ b/src/components/modal/modalComponent.tsx
@@ -37,7 +37,7 @@ interface ModalComponentProps {
     size: string
     price: number
   }
-  onProfileClick?: () => void
+  onProfileClick?: () => void // 프로필 클릭 핸들러
   onAccept?: () => void
   onReject?: () => void
 }
@@ -67,7 +67,7 @@ const ModalComponent = ({
     size: 'xlarge',
     price: 10,
   },
-  onProfileClick,
+  onProfileClick, // 프로필 클릭 핸들러 받기
   onAccept,
   onReject,
 }: ModalComponentProps) => {
@@ -389,6 +389,7 @@ const ModalComponent = ({
                   showDetails ? setShowDetails(false) : setShowDetails(true)
                 }}
                 showDetails={showDetails}
+                onClick={onProfileClick}
               />
             </div>
 
@@ -472,6 +473,7 @@ const ModalComponent = ({
                 name={userProfileProps.name}
                 department={userProfileProps.department}
                 makeDate={userProfileProps.makeDate}
+                onClick={onProfileClick}
               />
             </div>
           </div>
@@ -509,6 +511,7 @@ const ModalComponent = ({
                   showDetails ? setShowDetails(false) : setShowDetails(true)
                 }}
                 showDetails={showDetails}
+                onClick={onProfileClick}
               />
             </div>
 
@@ -591,6 +594,7 @@ const ModalComponent = ({
                   showDetails ? setShowDetails(false) : setShowDetails(true)
                 }}
                 showDetails={showDetails}
+                onClick={onProfileClick}
               />
             </div>
 

--- a/src/components/modal/modalUserProfile.tsx
+++ b/src/components/modal/modalUserProfile.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react'
 import { BackIcon } from '../icon/iconComponents'
+
 interface ModalUserProfileProps {
   profileImage: string
   name: string
@@ -35,6 +36,16 @@ const profileStyles = {
     justify-content: center;
     align-items: center;
     overflow: hidden;
+    cursor: pointer; /* 클릭 가능 표시 */
+    transition: transform 0.2s ease; /* 호버 효과 */
+
+    &:hover {
+      transform: scale(1.05);
+    }
+
+    &:active {
+      transform: scale(0.95);
+    }
   `,
 
   profileImageStyle: css`
@@ -115,15 +126,43 @@ export const ModalMatchingUserProfile = ({
   makeDate,
   onClick,
 }: ModalUserProfileProps) => {
+  // 프로필 이미지 클릭 핸들러
+  const handleProfileImageClick = (e: React.MouseEvent) => {
+    e.stopPropagation() // 부모 요소의 클릭 이벤트 방지
+    if (onClick) {
+      onClick()
+    }
+  }
+
+  // 전체 컨테이너 클릭 핸들러 (기존 onClick 유지)
+  const handleContainerClick = () => {
+    if (onClick) {
+      onClick()
+    }
+  }
+
   return (
     <div
       className="container"
       css={profileStyles.container}
-      onClick={onClick}
+      onClick={handleContainerClick}
       style={{ cursor: onClick ? 'pointer' : undefined }}
+      data-testid="profile-container"
     >
-      <div className="profile-image" css={profileStyles.profileImageWrapper}>
-        <img src={profileImage} css={profileStyles.profileImageStyle} />
+      <div
+        className="profile-image"
+        css={profileStyles.profileImageWrapper}
+        onClick={handleProfileImageClick}
+        title={onClick ? `${name}의 프로필 보기` : undefined}
+        style={{
+          cursor: onClick ? 'pointer' : 'default',
+        }}
+      >
+        <img
+          src={profileImage}
+          css={profileStyles.profileImageStyle}
+          alt={`${name}의 프로필 이미지`}
+        />
       </div>
 
       <div className="info-wrapper" css={profileStyles.infoWrapper}>
@@ -145,12 +184,33 @@ export const ModalMatchingFailureUserProfile = ({
   department,
   onBackClick,
   showDetails,
+  onClick, // 프로필 클릭 핸들러 받기
 }: ModalUserProfileProps) => {
+  // 프로필 이미지 클릭 핸들러
+  const handleProfileImageClick = (e: React.MouseEvent) => {
+    e.stopPropagation() // 부모 요소의 클릭 이벤트 방지
+    if (onClick) {
+      onClick()
+    }
+  }
+
   return (
     <div className="container" css={profileStyles.containerFailure}>
       <div className="leftBox" css={profileStyles.modalFailureLeftBox}>
-        <div className="profile-image" css={profileStyles.profileImageWrapper}>
-          <img src={profileImage} css={profileStyles.profileImageStyle} />
+        <div
+          className="profile-image"
+          css={profileStyles.profileImageWrapper}
+          onClick={handleProfileImageClick}
+          title={onClick ? `${name}의 프로필 보기` : undefined}
+          style={{
+            cursor: onClick ? 'pointer' : 'default',
+          }}
+        >
+          <img
+            src={profileImage}
+            css={profileStyles.profileImageStyle}
+            alt={`${name}의 프로필 이미지`}
+          />
         </div>
 
         <div className="info-wrapper" css={profileStyles.infoWrapper}>
@@ -167,6 +227,7 @@ export const ModalMatchingFailureUserProfile = ({
         <BackIcon
           css={profileStyles.backIcon(showDetails)}
           onClick={onBackClick}
+          data-testid="back-icon"
         />
       </div>
     </div>

--- a/src/pages/Chat/ChatRoom.tsx
+++ b/src/pages/Chat/ChatRoom.tsx
@@ -1064,6 +1064,15 @@ const ChatRoom = ({ chatId }: ChatRoomProps) => {
     }
   }, [stompClient, chatId])
 
+  // 프로필 이미지 클릭 핸들러
+  const handleProfileClick = () => {
+    if (otherUserId) {
+      navigate(`/mypage/${otherUserId}`)
+    } else {
+      showToast('상대방 정보를 찾을 수 없습니다.', 'error')
+    }
+  }
+
   return (
     <RootContainer>
       <TopBar
@@ -1175,6 +1184,9 @@ const ChatRoom = ({ chatId }: ChatRoomProps) => {
                           ? undefined
                           : otherProfileImageFromNav ||
                             '/default-profile-image.png'
+                      }
+                      onProfileClick={
+                        message.isMe ? undefined : handleProfileClick
                       }
                     >
                       <EmoticonWrapper>
@@ -1481,6 +1493,9 @@ const ChatRoom = ({ chatId }: ChatRoomProps) => {
                         isContinuous={false}
                         isCustomFormMake={true}
                         onClick={handleFormClick}
+                        onProfileClick={
+                          message.isMe ? undefined : handleProfileClick
+                        }
                       />
                     </div>
                   )
@@ -1512,6 +1527,9 @@ const ChatRoom = ({ chatId }: ChatRoomProps) => {
                         isContinuous={false}
                         isCustomFormMake={true}
                         onClick={handleFormClick}
+                        onProfileClick={
+                          message.isMe ? undefined : handleProfileClick
+                        }
                       />
                     </div>
                   )
@@ -1538,6 +1556,9 @@ const ChatRoom = ({ chatId }: ChatRoomProps) => {
                         isContinuous={false}
                         isCustomFormMake={true}
                         onClick={handleFormClick}
+                        onProfileClick={
+                          message.isMe ? undefined : handleProfileClick
+                        }
                       />
                     </div>
                   )
@@ -1571,6 +1592,9 @@ const ChatRoom = ({ chatId }: ChatRoomProps) => {
                         : otherProfileImageFromNav ||
                           '/default-profile-image.png'
                     }
+                    onProfileClick={
+                      message.isMe ? undefined : handleProfileClick
+                    }
                   >
                     {message.content}
                   </Bubble>
@@ -1585,6 +1609,7 @@ const ChatRoom = ({ chatId }: ChatRoomProps) => {
                 profileImage={
                   otherProfileImageFromNav || '/default-profile-image.png'
                 }
+                onProfileClick={handleProfileClick}
               >
                 <div style={{ padding: '4px 8px' }}>
                   <span style={{ fontSize: '14px' }}>입력 중...</span>

--- a/src/pages/Matching/application.tsx
+++ b/src/pages/Matching/application.tsx
@@ -94,6 +94,10 @@ const MatchedApplication = ({}: MatchedApplicationProps) => {
     handleOpenModal(application)
   }
 
+  const handleProfileClick = (userId: number) => {
+    navigate(`/mypage/${userId}`)
+  }
+
   const handleMatchingRequest = async () => {
     if (!selectedApplication || !matchedRoom) return
 
@@ -149,6 +153,9 @@ const MatchedApplication = ({}: MatchedApplicationProps) => {
           onMessageChange: () => {},
           messageValue: selectedApplication.message,
         }}
+        onProfileClick={() =>
+          handleProfileClick(selectedApplication.waitingUserId)
+        }
       />
     )
   }
@@ -179,6 +186,9 @@ const MatchedApplication = ({}: MatchedApplicationProps) => {
                 onClick={() => handleMatchApplicationClick(application)}
                 message={application.message}
                 borderSet={index < applications.length - 1}
+                onProfileClick={() =>
+                  handleProfileClick(application.waitingUserId)
+                }
               />
             ))
           ) : (

--- a/src/pages/Matching/matchedInfo.tsx
+++ b/src/pages/Matching/matchedInfo.tsx
@@ -367,6 +367,14 @@ const MatchedInfo = ({}: MatchedInfoProps) => {
     setCreatorProfile(null)
   }
 
+  const handleProfileClick = (userId: number, isAnonymous: boolean = false) => {
+    if (!isAnonymous && userId) {
+      navigate(`/mypage/${userId}`)
+    } else {
+      showToast('익명 사용자의 프로필은 볼 수 없습니다.', 'error')
+    }
+  }
+
   const handleMatchingCancelRequest = async () => {
     if (!selectedApplication) return
 
@@ -443,6 +451,7 @@ const MatchedInfo = ({}: MatchedInfoProps) => {
             onMessageChange: () => {},
             messageValue: '',
           }}
+          onProfileClick={() => {}}
         />
       )
     }
@@ -472,6 +481,9 @@ const MatchedInfo = ({}: MatchedInfoProps) => {
             onMessageChange: () => {},
             messageValue: selectedApplication.message || '',
           }}
+          onProfileClick={() =>
+            handleProfileClick(creatorProfile.userId, matchingDetail.anonymous)
+          }
         />
       )
     }
@@ -498,6 +510,12 @@ const MatchedInfo = ({}: MatchedInfoProps) => {
           onMessageChange: () => {},
           messageValue: selectedApplication.message || '',
         }}
+        onProfileClick={() =>
+          handleProfileClick(
+            selectedApplication.creatorId,
+            selectedApplication.anonymous
+          )
+        }
       />
     )
   }


### PR DESCRIPTION
- 매칭 신청자 목록에서 프로필 이미지 클릭 시 해당 사용자 프로필로 이동
- 신청 보낸 매칭방 목록 모달에서 프로필 이미지 클릭 기능 추가
- 채팅방 내 메시지 버블의 프로필 이미지 클릭 기능 구현
- 모든 모달에서 프로필 이미지 클릭으로 프로필 페이지 이동 가능

## 🪐 작업 내용
  - 기존 `onClick` prop을 활용하여 프로필 클릭 기능 구현