### PR TITLE
😎fix: 세션오염 문제 해결

### DIFF
--- a/src/pages/Chat/ChatHome.tsx
+++ b/src/pages/Chat/ChatHome.tsx
@@ -470,7 +470,7 @@ const ChatHome = ({ matchId }: ChatHomeProps) => {
                   <div
                     style={{
                       position: 'absolute',
-                      bottom: '20px',
+                      bottom: '25px',
                       right: '8px',
                       background:
                         'linear-gradient(45deg, #feecc4 0%, #fff3d8 50%, #f0daa9 100%)',

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -367,10 +367,7 @@ const HomePage = () => {
           <PlainSectionContainer>
             <SectionTitleContainer>
               <SectionTitle>지금 필요한 학생소식</SectionTitle>
-              <SeeMoreButton
-                onClick={() => console.log('더보기 clicked')}
-                style={{ display: 'none' }}
-              >
+              <SeeMoreButton onClick={() => console.log('더보기 clicked')}>
                 더보기
               </SeeMoreButton>
             </SectionTitleContainer>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -367,9 +367,6 @@ const HomePage = () => {
           <PlainSectionContainer>
             <SectionTitleContainer>
               <SectionTitle>지금 필요한 학생소식</SectionTitle>
-              <SeeMoreButton onClick={() => console.log('더보기 clicked')}>
-                더보기
-              </SeeMoreButton>
             </SectionTitleContainer>
 
             {/* 카드 뉴스 컴포넌트 영역 */}

--- a/src/pages/Magazine/MagazineContentParser.ts
+++ b/src/pages/Magazine/MagazineContentParser.ts
@@ -1,11 +1,7 @@
-/**
- * 매거진 콘텐츠 파서 - 에디터 내용을 API 형식에 맞게 변환
- *
- * 이미지 처리 개선 버전
- */
+// 매거진 콘텐츠 파서 - 에디터 내용을 API 형식에 맞게 변환
 import { EmoticonType } from '../../components/emoticon/Emoticon'
 import { mapEmoticonTypeToId } from './EmoticonService'
-import { getTokenCookie } from '../../utils/fetchWithRefresh'
+import { getTokenCookie, fetchWithRefresh } from '../../utils/fetchWithRefresh'
 
 /**
  * 매거진 게시 함수
@@ -47,7 +43,7 @@ export const postMagazine = async (
     if (imagesToUpload.length > 0) {
       try {
         console.log(`이미지 업로드 시작: ${imagesToUpload.length}개`)
-        // 이미지 업로드 API 엔드포인트
+
         const apiUrl = 'https://mindmate.shop/api/magazines/image'
         const formData = new FormData()
 
@@ -57,15 +53,12 @@ export const postMagazine = async (
           formData.append('files', blob, `image_${index}.jpg`)
         })
 
-        // 직접 fetch 호출
         console.log('이미지 업로드 요청 시작...')
-        const response = await fetch(apiUrl, {
+
+        // fetchWithRefresh 사용
+        const response = await fetchWithRefresh(apiUrl, {
           method: 'POST',
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-          credentials: 'include',
-          body: formData,
+          body: formData, // FormData는 Content-Type 헤더를 자동으로 설정함
         })
 
         // 응답 상태 로깅
@@ -184,15 +177,20 @@ export const postMagazine = async (
     )
 
     // 5. 매거진 게시 API 호출
-    const response = await fetch('https://mindmate.shop/api/magazines', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      },
-      credentials: 'include',
-      body: JSON.stringify(magazineRequest),
-    })
+    console.log('=== 매거진 게시 시작 ===')
+
+    // fetchWithRefresh 사용 (토큰 관리 자동화)
+    const response = await fetchWithRefresh(
+      'https://mindmate.shop/api/magazines',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          // Authorization 헤더는 fetchWithRefresh가 자동으로 추가
+        },
+        body: JSON.stringify(magazineRequest),
+      }
+    )
 
     // 응답 로깅
     console.log(
@@ -253,7 +251,7 @@ export const convertCategoryToApiFormat = (category: string): string => {
     취업: 'EMPLOYMENT',
     학업: 'ACADEMIC',
     인간관계: 'RELATIONSHIP',
-    경제: 'ECONOMIC',
+    경제: 'FINANCIAL',
     기타: 'OTHER',
   }
 

--- a/src/pages/Magazine/styles/MagazineStyles.tsx
+++ b/src/pages/Magazine/styles/MagazineStyles.tsx
@@ -141,6 +141,129 @@ export const MagazineContent = styled.div`
     font-size: 2em !important;
   }
 
+  /* 텍스트 색상 - 모든 가능한 선택자로 지원 */
+  .ql-color-red,
+  [style*='color: red'],
+  span[style*='color: red'] {
+    color: red !important;
+  }
+
+  .ql-color-orange,
+  [style*='color: orange'],
+  span[style*='color: orange'] {
+    color: orange !important;
+  }
+
+  .ql-color-yellow,
+  [style*='color: yellow'],
+  span[style*='color: yellow'] {
+    color: yellow !important;
+  }
+
+  .ql-color-green,
+  [style*='color: green'],
+  span[style*='color: green'] {
+    color: green !important;
+  }
+
+  .ql-color-blue,
+  [style*='color: blue'],
+  span[style*='color: blue'] {
+    color: blue !important;
+  }
+
+  .ql-color-purple,
+  [style*='color: purple'],
+  span[style*='color: purple'] {
+    color: purple !important;
+  }
+
+  /* 일반적인 색상 값들도 지원 */
+  [style*='color: #'] {
+    /* 이미 인라인 스타일로 적용된 색상 유지 */
+  }
+
+  [style*='color: rgb'] {
+    /* RGB 색상 값 유지 */
+  }
+
+  /* === 핵심: 배경색 스타일 완전 지원 === */
+
+  /* Quill 배경색 클래스 */
+  .ql-bg-red,
+  .ql-background-red,
+  [style*='background-color: red'],
+  span[style*='background-color: red'] {
+    background-color: red !important;
+    padding: 2px 4px !important;
+    border-radius: 3px !important;
+  }
+
+  .ql-bg-orange,
+  .ql-background-orange,
+  [style*='background-color: orange'],
+  span[style*='background-color: orange'] {
+    background-color: orange !important;
+    padding: 2px 4px !important;
+    border-radius: 3px !important;
+  }
+
+  .ql-bg-yellow,
+  .ql-background-yellow,
+  [style*='background-color: yellow'],
+  span[style*='background-color: yellow'] {
+    background-color: yellow !important;
+    padding: 2px 4px !important;
+    border-radius: 3px !important;
+  }
+
+  .ql-bg-green,
+  .ql-background-green,
+  [style*='background-color: green'],
+  span[style*='background-color: green'] {
+    background-color: green !important;
+    padding: 2px 4px !important;
+    border-radius: 3px !important;
+  }
+
+  .ql-bg-blue,
+  .ql-background-blue,
+  [style*='background-color: blue'],
+  span[style*='background-color: blue'] {
+    background-color: blue !important;
+    padding: 2px 4px !important;
+    border-radius: 3px !important;
+  }
+
+  .ql-bg-purple,
+  .ql-background-purple,
+  [style*='background-color: purple'],
+  span[style*='background-color: purple'] {
+    background-color: purple !important;
+    padding: 2px 4px !important;
+    border-radius: 3px !important;
+  }
+
+  /* 모든 배경색 인라인 스타일 지원 */
+  [style*='background-color: #'] {
+    padding: 2px 4px !important;
+    border-radius: 3px !important;
+    /* 인라인 스타일 배경색 유지 */
+  }
+
+  [style*='background-color: rgb'] {
+    padding: 2px 4px !important;
+    border-radius: 3px !important;
+    /* RGB 배경색 유지 */
+  }
+
+  /* 추가 배경색 선택자들 */
+  span[style*='background:'],
+  span[style*='background-color:'] {
+    padding: 2px 4px !important;
+    border-radius: 3px !important;
+  }
+
   /* 정렬 스타일 */
   .ql-align-center {
     text-align: center;
@@ -152,6 +275,18 @@ export const MagazineContent = styled.div`
 
   .ql-align-justify {
     text-align: justify;
+  }
+
+  /* 모든 span 태그의 스타일 속성 보존 */
+  span {
+    /* 인라인 스타일 우선순위 보장 */
+  }
+
+  /* 중첩된 스타일 조합 지원 */
+  span[style*='color:'][style*='background-color:'] {
+    /* 색상과 배경색이 함께 적용된 경우 */
+    padding: 2px 4px !important;
+    border-radius: 3px !important;
   }
 
   /* 이모티콘 스타일 */

--- a/src/utils/fetchWithRefresh.ts
+++ b/src/utils/fetchWithRefresh.ts
@@ -18,7 +18,14 @@ declare global {
   }
 }
 
+// isSessionExpired 플래그는 유지합니다.
 let isSessionExpired = false
+
+// isSessionExpired를 외부에서 리셋
+export function resetSessionExpiredFlag() {
+  isSessionExpired = false
+  console.log('isSessionExpired 플래그가 리셋되었습니다.')
+}
 
 export async function fetchWithRefresh(input: RequestInfo, init?: RequestInit) {
   const accessToken = getTokenCookie('accessToken')
@@ -39,37 +46,17 @@ export async function fetchWithRefresh(input: RequestInfo, init?: RequestInit) {
   let res = await fetch(input, { ...init, headers, credentials: 'include' })
 
   if (res.status === 401) {
+    //console.log('401 에러 감지, 토큰 갱신 시도...')
+
     const refreshToken = getTokenCookie('refreshToken')
-    const refreshRes = await fetch('https://mindmate.shop/api/auth/refresh', {
-      method: 'POST',
-      headers: {
-        ...(refreshToken ? { Authorization: `Bearer ${refreshToken}` } : {}),
-        'Content-Type': 'application/json',
-      },
-      credentials: 'include',
-    })
-    if (refreshRes.ok) {
-      const refreshData = await refreshRes.json()
-      if (refreshData.accessToken)
-        setTokenCookie(refreshData.accessToken, 'accessToken')
-      if (refreshData.refreshToken)
-        setTokenCookie(refreshData.refreshToken, 'refreshToken')
-      const newAccessToken = getTokenCookie('accessToken')
-      const retryHeaders = {
-        ...(init?.headers || {}),
-        ...(newAccessToken
-          ? { Authorization: `Bearer ${newAccessToken}` }
-          : {}),
-      }
-      res = await fetch(input, {
-        ...init,
-        headers: retryHeaders,
-        credentials: 'include',
-      })
-    } else {
-      // 세션 만료 처리: 한 번만 실행
+    //console.log('Refresh token 존재 여부:', !!refreshToken)
+
+    // 리프레시 토큰이 없으면 세션 만료 처리
+    if (!refreshToken) {
+      console.warn('리프레시 토큰이 없습니다. 로그인 페이지로 리디렉션합니다.')
       if (!isSessionExpired) {
-        isSessionExpired = true
+        // 세션 만료 플래그 확인
+        isSessionExpired = true // 플래그 설정
         setTokenCookie('', 'accessToken', -1)
         setTokenCookie('', 'refreshToken', -1)
         localStorage.removeItem('auth-store')
@@ -79,13 +66,90 @@ export async function fetchWithRefresh(input: RequestInfo, init?: RequestInit) {
         ) {
           window.clearUser()
         }
-        // alert('세션이 만료되었습니다. 다시 로그인 해주세요.')
         localStorage.clear()
         window.location.href = '/onboarding'
       }
-      throw new Error('토큰 갱신 실패')
+      throw new Error('인증이 필요합니다.')
+    }
+
+    try {
+      // 토큰 갱신 요청: 이전 코드의 URL과 헤더, 본문 방식 사용
+      const refreshRes = await fetch('https://mindmate.shop/api/auth/refresh', {
+        // 이전 URL로 복원
+        method: 'POST',
+        headers: {
+          ...(refreshToken ? { Authorization: `Bearer ${refreshToken}` } : {}), // 이전 헤더 방식으로 복원
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      })
+
+      if (refreshRes.ok) {
+        const refreshData = await refreshRes.json()
+        // 쿠키 설정 방식은 이전 코드의 기본값 사용 (days 인자 제거)
+        if (refreshData.accessToken)
+          setTokenCookie(refreshData.accessToken, 'accessToken')
+        if (refreshData.refreshToken)
+          setTokenCookie(refreshData.refreshToken, 'refreshToken') // 이전 코드에는 이 줄이 없었지만, 토큰 갱신 후 리프레시 토큰도 업데이트하는 것이 좋으니 유지합니다.
+
+        const newAccessToken = getTokenCookie('accessToken')
+        const retryHeaders = {
+          ...(init?.headers || {}),
+          ...(newAccessToken
+            ? { Authorization: `Bearer ${newAccessToken}` }
+            : {}),
+        }
+
+        // 토큰 갱신 성공 시 isSessionExpired 플래그 리셋
+        isSessionExpired = false
+
+        res = await fetch(input, {
+          ...init,
+          headers: retryHeaders,
+          credentials: 'include',
+        })
+      } else {
+        // 토큰 갱신 실패 처리
+        if (!isSessionExpired) {
+          // 세션 만료 플래그 확인
+          isSessionExpired = true // 플래그 설정
+          setTokenCookie('', 'accessToken', -1)
+          setTokenCookie('', 'refreshToken', -1)
+          localStorage.removeItem('auth-store')
+          if (
+            typeof window !== 'undefined' &&
+            typeof window.clearUser === 'function'
+          ) {
+            window.clearUser()
+          }
+          localStorage.clear()
+          window.location.href = '/onboarding'
+        }
+        throw new Error('토큰 갱신 실패')
+      }
+    } catch (error) {
+      console.error('토큰 갱신 중 오류:', error)
+
+      // 네트워크 오류 등으로 갱신이 불가능한 경우
+      if (!isSessionExpired) {
+        // 세션 만료 플래그 확인
+        isSessionExpired = true // 플래그 설정
+        setTokenCookie('', 'accessToken', -1)
+        setTokenCookie('', 'refreshToken', -1)
+        localStorage.removeItem('auth-store')
+        if (
+          typeof window !== 'undefined' &&
+          typeof window.clearUser === 'function'
+        ) {
+          window.clearUser()
+        }
+        localStorage.clear()
+        window.location.href = '/onboarding'
+      }
+      throw error
     }
   }
+
   return res
 }
 
@@ -93,6 +157,7 @@ export async function fetchWithRefresh(input: RequestInfo, init?: RequestInit) {
 export function decodeJWT(token: string): any {
   try {
     const payload = token.split('.')[1]
+    // 이전 코드의 Base64URL-safe 디코딩 로직을 다시 추가
     const decoded = atob(payload.replace(/-/g, '+').replace(/_/g, '/'))
     return JSON.parse(decoded)
   } catch (e) {


### PR DESCRIPTION
## 🛰️ 작업 배경
- 매거진 게시물 작성이 최대 4회까지밖만 가능한 오류 발생
- 같은 노트북에서 다른 계정으로 로그인해도 동일하게 5번째 매거진 등록부터 실패
- 클라이언트(노트북) 환경 또는 해당 클라이언트에서 발생하는 요청 패턴에 반응하는 서버 측의 특정 로직/버그로 파악

## 🪐 작업 내용
- 매거진 에디터 기능(글씨의 배경색 지정) 수정
- 세션 만료(isSessionExpired) 플래그 관리 강화:
1. isSessionExpired 전역 플래그를 외부에서 false로 명시적으로 리셋할 수 있는 resetSessionExpiredFlag 함수를 추가
2. 토큰 갱신이 성공적으로 이루어졌을 때 isSessionExpired 플래그를 false로 리셋하도록 하여, 이전 세션의 인증 실패 상태가 다음 세션에 영향을 미치는 문제를 방지